### PR TITLE
Adding Keplr Intereactions for Wallet and Handle an Edge Case

### DIFF
--- a/commands/keplr.js
+++ b/commands/keplr.js
@@ -141,39 +141,20 @@ const keplr = {
     );
   },
   async acceptAccess() {
-    const result = await playwright.switchToKeplrNotification();
-
-    if (
-      result.err &&
-      result.message === 'Unable to Switch to Notification Window'
-    ) {
-      let pages = await playwright.browser().contexts()[0].pages();
-
-      for (const page of pages) {
-        const pageContent = await page.textContent('html');
-        if (
-          pageContent.includes('agoric1p2aqakv3ulz4qfy2nut86j9gx0dx0yw09h96md')
-        ) {
-          return true;
-        }
-      }
-
-      return false;
-    }
-
+    const notificationPage = await playwright.switchToKeplrNotification();
     await playwright.waitAndClick(
       notificationPageElements.approveButton,
-      result.page,
+      notificationPage,
       { waitForEvent: 'close' },
     );
     return true;
   },
 
   async confirmTransaction() {
-    const result = await playwright.switchToKeplrNotification();
+    const notificationPage = await playwright.switchToKeplrNotification();
     await playwright.waitAndClick(
       notificationPageElements.approveButton,
-      result.page,
+      notificationPage,
       { waitForEvent: 'close' },
     );
     return true;

--- a/commands/keplr.js
+++ b/commands/keplr.js
@@ -141,20 +141,39 @@ const keplr = {
     );
   },
   async acceptAccess() {
-    const notificationPage = await playwright.switchToKeplrNotification();
+    const result = await playwright.switchToKeplrNotification();
+
+    if (
+      result.err &&
+      result.message === 'Unable to Switch to Notification Window'
+    ) {
+      let pages = await playwright.browser().contexts()[0].pages();
+
+      for (const page of pages) {
+        const pageContent = await page.textContent('html');
+        if (
+          pageContent.includes('agoric1p2aqakv3ulz4qfy2nut86j9gx0dx0yw09h96md')
+        ) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+
     await playwright.waitAndClick(
       notificationPageElements.approveButton,
-      notificationPage,
+      result.page,
       { waitForEvent: 'close' },
     );
     return true;
   },
 
   async confirmTransaction() {
-    const notificationPage = await playwright.switchToKeplrNotification();
+    const result = await playwright.switchToKeplrNotification();
     await playwright.waitAndClick(
       notificationPageElements.approveButton,
-      notificationPage,
+      result.page,
       { waitForEvent: 'close' },
     );
     return true;

--- a/commands/keplr.js
+++ b/commands/keplr.js
@@ -35,24 +35,48 @@ const keplr = {
     };
   },
 
-  async importWallet(secretWordsOrPrivateKey, password, newAccount) {
+  async importWallet(secretWords, password, newAccount) {
     await playwright.waitAndClickByText(
-      onboardingElements.createWalletButton,
+      newAccount
+        ? onboardingElements.createWalletButton
+        : onboardingElements.existingWalletButton,
       await playwright.keplrWindow(),
     );
+
     await playwright.waitAndClickByText(
-      onboardingElements.importRecoveryPhraseButton,
+      newAccount
+        ? onboardingElements.importRecoveryPhraseButton
+        : onboardingElements.useRecoveryPhraseButton,
       await playwright.keplrWindow(),
     );
-    await playwright.waitAndClickByText(
-      onboardingElements.useRecoveryPhraseButton,
-      await playwright.keplrWindow(),
-    );
+
+    newAccount &&
+      (await playwright.waitAndClickByText(
+        onboardingElements.useRecoveryPhraseButton,
+        await playwright.keplrWindow(),
+      ));
 
     if (secretWords.includes(' ')) {
       await module.exports.importWalletWithPhrase(secretWords, password);
     } else {
       await module.exports.importWalletWithPrivateKey(secretWords, password);
+    }
+
+    await playwright.waitAndType(
+      onboardingElements.walletInput,
+      onboardingElements.walletName,
+    );
+
+    const passwordFieldExists = await playwright.doesElementExist(
+      onboardingElements.passwordInput,
+    );
+
+    if (passwordFieldExists) {
+      await playwright.waitAndType(onboardingElements.passwordInput, password);
+      await playwright.waitAndType(
+        onboardingElements.confirmPasswordInput,
+        password,
+      );
     }
 
     await playwright.waitAndClick(
@@ -84,7 +108,7 @@ const keplr = {
 
     return true;
   },
-  async importWalletWithPhrase(secretWords, password) {
+  async importWalletWithPhrase(secretWords) {
     await playwright.waitAndClickByText(
       onboardingElements.phraseCount24,
       await playwright.keplrWindow(),
@@ -102,18 +126,8 @@ const keplr = {
       onboardingElements.submitPhraseButton,
       await playwright.keplrWindow(),
     );
-
-    await playwright.waitAndType(
-      onboardingElements.walletInput,
-      onboardingElements.walletName,
-    );
-    await playwright.waitAndType(onboardingElements.passwordInput, password);
-    await playwright.waitAndType(
-      onboardingElements.confirmPasswordInput,
-      password,
-    );
   },
-  async importWalletWithPrivateKey(privateKey, password) {
+  async importWalletWithPrivateKey(privateKey) {
     await playwright.clickByText(onboardingElements.phrasePrivateKey);
 
     await playwright.waitAndTypeByLocator(
@@ -125,23 +139,6 @@ const keplr = {
       onboardingElements.submitPhraseButton,
       await playwright.keplrWindow(),
     );
-
-    await playwright.waitAndType(
-      onboardingElements.walletInput,
-      onboardingElements.walletName,
-    );
-
-    const passwordFieldExists = await playwright.doesElementExist(
-      onboardingElements.passwordInput,
-    );
-
-    if (passwordFieldExists) {
-      await playwright.waitAndType(onboardingElements.passwordInput, password);
-      await playwright.waitAndType(
-        onboardingElements.confirmPasswordInput,
-        password,
-      );
-    }
   },
   async acceptAccess() {
     const notificationPage = await playwright.switchToKeplrNotification();

--- a/commands/keplr.js
+++ b/commands/keplr.js
@@ -37,52 +37,22 @@ const keplr = {
 
   async importWallet(secretWordsOrPrivateKey, password, newAccount) {
     await playwright.waitAndClickByText(
-      newAccount
-        ? onboardingElements.createWalletButton
-        : onboardingElements.existingWalletButton,
+      onboardingElements.createWalletButton,
       await playwright.keplrWindow(),
     );
-
     await playwright.waitAndClickByText(
-      newAccount
-        ? onboardingElements.importRecoveryPhraseButton
-        : onboardingElements.useRecoveryPhraseButton,
+      onboardingElements.importRecoveryPhraseButton,
+      await playwright.keplrWindow(),
+    );
+    await playwright.waitAndClickByText(
+      onboardingElements.useRecoveryPhraseButton,
       await playwright.keplrWindow(),
     );
 
-    newAccount &&
-      (await playwright.waitAndClickByText(
-        onboardingElements.useRecoveryPhraseButton,
-        await playwright.keplrWindow(),
-      ));
-
-    if (secretWordsOrPrivateKey.includes(' ')) {
-      await module.exports.importWalletWithPhrase(
-        secretWordsOrPrivateKey,
-        password,
-      );
+    if (secretWords.includes(' ')) {
+      await module.exports.importWalletWithPhrase(secretWords, password);
     } else {
-      await module.exports.importWalletWithPrivateKey(
-        secretWordsOrPrivateKey,
-        password,
-      );
-    }
-
-    await playwright.waitAndType(
-      onboardingElements.walletInput,
-      onboardingElements.walletName,
-    );
-
-    const passwordFieldExists = await playwright.doesElementExist(
-      onboardingElements.passwordInput,
-    );
-
-    if (passwordFieldExists) {
-      await playwright.waitAndType(onboardingElements.passwordInput, password);
-      await playwright.waitAndType(
-        onboardingElements.confirmPasswordInput,
-        password,
-      );
+      await module.exports.importWalletWithPrivateKey(secretWords, password);
     }
 
     await playwright.waitAndClick(
@@ -114,7 +84,7 @@ const keplr = {
 
     return true;
   },
-  async importWalletWithPhrase(secretWords) {
+  async importWalletWithPhrase(secretWords, password) {
     await playwright.waitAndClickByText(
       onboardingElements.phraseCount24,
       await playwright.keplrWindow(),
@@ -132,13 +102,19 @@ const keplr = {
       onboardingElements.submitPhraseButton,
       await playwright.keplrWindow(),
     );
-  },
-  async importWalletWithPrivateKey(privateKey) {
-    await playwright.waitAndClickByText(
-      onboardingElements.phrasePrivateKey,
-      await playwright.keplrWindow(),
-      true,
+
+    await playwright.waitAndType(
+      onboardingElements.walletInput,
+      onboardingElements.walletName,
     );
+    await playwright.waitAndType(onboardingElements.passwordInput, password);
+    await playwright.waitAndType(
+      onboardingElements.confirmPasswordInput,
+      password,
+    );
+  },
+  async importWalletWithPrivateKey(privateKey, password) {
+    await playwright.clickByText(onboardingElements.phrasePrivateKey);
 
     await playwright.waitAndTypeByLocator(
       onboardingElements.textAreaSelector,
@@ -149,6 +125,23 @@ const keplr = {
       onboardingElements.submitPhraseButton,
       await playwright.keplrWindow(),
     );
+
+    await playwright.waitAndType(
+      onboardingElements.walletInput,
+      onboardingElements.walletName,
+    );
+
+    const passwordFieldExists = await playwright.doesElementExist(
+      onboardingElements.passwordInput,
+    );
+
+    if (passwordFieldExists) {
+      await playwright.waitAndType(onboardingElements.passwordInput, password);
+      await playwright.waitAndType(
+        onboardingElements.confirmPasswordInput,
+        password,
+      );
+    }
   },
   async acceptAccess() {
     const notificationPage = await playwright.switchToKeplrNotification();

--- a/commands/playwright-keplr.js
+++ b/commands/playwright-keplr.js
@@ -79,7 +79,11 @@ module.exports = {
     return keplrNotificationWindow;
   },
 
-  async waitAndClickByText(text, page = keplrWindow, exact = false) {
+  async clickByText(text, page = keplrWindow) {
+    await page.click(`text="${text}"`);
+  },
+
+  async waitAndClickByText(text, page = keplrWindow) {
     await module.exports.waitForByText(text, page);
     const element = `:is(:text-is("${text}")${exact ? '' : `, :text("${text}")`})`;
     await page.click(element);
@@ -358,9 +362,7 @@ module.exports = {
     const keplrExtensionData = (await module.exports.getExtensionsData()).keplr;
     const browserContext = await browser.contexts()[0];
     keplrRegistrationWindow = await browserContext.newPage();
-    await keplrRegistrationWindow.goto(
-      `chrome-extension://${keplrExtensionData.id}/register.html`,
-    );
+    await keplrRegistrationWindow.goto(`chrome-extension://${keplrExtensionData.id}/register.html`); 
     return true;
   },
   async switchToKeplrNotification() {

--- a/commands/playwright-keplr.js
+++ b/commands/playwright-keplr.js
@@ -385,7 +385,7 @@ module.exports = {
         retries = 0;
         await page.bringToFront();
         await module.exports.waitUntilStable(page);
-        return { page, err: false };
+        return page
       }
     }
     await sleep(200);
@@ -394,10 +394,9 @@ module.exports = {
       return await module.exports.switchToKeplrNotification();
     } else if (retries >= 50) {
       retries = 0;
-      return {
-        err: true,
-        message: 'Unable to Switch to Notification Window',
-      };
+      throw new Error(
+        '[switchToKeplrNotification] Max amount of retries to switch to keplr notification window has been reached. It was never found.',
+      );
     }
   },
 };

--- a/commands/playwright-keplr.js
+++ b/commands/playwright-keplr.js
@@ -79,6 +79,10 @@ module.exports = {
     return keplrNotificationWindow;
   },
 
+  browser() {
+    return browser;
+  },
+
   async clickByText(text, page = keplrWindow) {
     await page.click(`text="${text}"`);
   },
@@ -362,7 +366,9 @@ module.exports = {
     const keplrExtensionData = (await module.exports.getExtensionsData()).keplr;
     const browserContext = await browser.contexts()[0];
     keplrRegistrationWindow = await browserContext.newPage();
-    await keplrRegistrationWindow.goto(`chrome-extension://${keplrExtensionData.id}/register.html`); 
+    await keplrRegistrationWindow.goto(
+      `chrome-extension://${keplrExtensionData.id}/register.html`,
+    );
     return true;
   },
   async switchToKeplrNotification() {
@@ -379,7 +385,7 @@ module.exports = {
         retries = 0;
         await page.bringToFront();
         await module.exports.waitUntilStable(page);
-        return page;
+        return { page, err: false };
       }
     }
     await sleep(200);
@@ -388,9 +394,10 @@ module.exports = {
       return await module.exports.switchToKeplrNotification();
     } else if (retries >= 50) {
       retries = 0;
-      throw new Error(
-        '[switchToKeplrNotification] Max amount of retries to switch to keplr notification window has been reached. It was never found.',
-      );
+      return {
+        err: true,
+        message: 'Unable to Switch to Notification Window',
+      };
     }
   },
 };

--- a/pages/keplr/first-time-flow-page.js
+++ b/pages/keplr/first-time-flow-page.js
@@ -1,7 +1,9 @@
 const createWalletButton = 'Create a new wallet';
-const importRecoveryPhraseButton = 'Import existing recovery phrase';
+const existingWalletButton = 'Import an existing wallet';
+const importRecoveryPhraseButton = 'Import existing recovery phrase'; 
 const useRecoveryPhraseButton = 'Use recovery phrase or private key';
 const phraseCount24 = '24 words';
+const phrasePrivateKey = 'Private key';
 const walletInput = 'input[name="name"]:focus';
 const passwordInput = 'input[name="password"]';
 const confirmPasswordInput = 'input[name="confirmPassword"]';
@@ -15,10 +17,12 @@ const textAreaSelector = 'textbox';
 const submitPhraseButton = 'button[type="submit"]';
 
 module.exports.onboardingElements = {
+  existingWalletButton,
   createWalletButton,
   importRecoveryPhraseButton,
   useRecoveryPhraseButton,
   phraseCount24,
+  phrasePrivateKey,
   walletInput,
   walletName,
   passwordInput,

--- a/plugins/keplr-plugin.js
+++ b/plugins/keplr-plugin.js
@@ -59,6 +59,7 @@ module.exports = (on, config) => {
     clearWindows: playwright.clearWindows,
     isCypressWindowActive: playwright.isCypressWindowActive,
     switchToExtensionWindow: playwright.switchToKeplrWindow,
+    switchToExtensionRegistrationWindow: playwright.switchToKeplrRegistrationWindow,
 
     // keplr commands
     importWallet: keplr.importWallet,
@@ -66,17 +67,13 @@ module.exports = (on, config) => {
     confirmTransaction: keplr.confirmTransaction,
     setupWallet: async ({
       secretWordsOrPrivateKey,
-      network,
       password,
-      enableAdvancedSettings,
-      enableExperimentalSettings,
+      newAccount,
     }) => {
       await keplr.initialSetup(null, {
         secretWordsOrPrivateKey,
-        network,
         password,
-        enableAdvancedSettings,
-        enableExperimentalSettings,
+        newAccount
       });
       return true;
     },

--- a/support/commands.js
+++ b/support/commands.js
@@ -444,3 +444,11 @@ Cypress.Commands.add('switchToExtensionWindow', () => {
 Cypress.Commands.add('switchToExtensionRegistrationWindow', () => {
   return cy.task('switchToExtensionRegistrationWindow');
 });
+
+Cypress.Commands.add('makeOfferAndConfirmTransaction', () => {
+  cy.contains('agoric1p2aqakv3ulz4qfy2nut86j9gx0dx0yw09h96md');
+  cy.contains('Make an Offer').click();
+  return cy.confirmTransaction().then(taskCompleted => {
+    expect(taskCompleted).to.be.true;
+  });
+});

--- a/support/commands.js
+++ b/support/commands.js
@@ -415,10 +415,12 @@ Cypress.Commands.add(
   (
     secretWordsOrPrivateKey = 'orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology',
     password = 'Test1234',
+    newAccount = false
   ) => {
     return cy.task('setupWallet', {
       secretWordsOrPrivateKey,
-      password
+      password,
+      newAccount
     });
   },
 );
@@ -437,4 +439,8 @@ Cypress.Commands.add('isExtensionWindowActive', () => {
 
 Cypress.Commands.add('switchToExtensionWindow', () => {
   return cy.task('switchToExtensionWindow');
+});
+
+Cypress.Commands.add('switchToExtensionRegistrationWindow', () => {
+  return cy.task('switchToExtensionRegistrationWindow');
 });

--- a/tests/e2e/specs/keplr/keplr-spec.js
+++ b/tests/e2e/specs/keplr/keplr-spec.js
@@ -24,11 +24,10 @@ describe('Keplr', () => {
           expect(setupFinished).to.be.true;
 
           cy.visit('/');
+          // We're not calling the acceptAccess function
+          // The assumption here is that user is already connected to the wallet when the first test case ran
           cy.contains('Connect Wallet').click();
-          cy.acceptAccess().then(taskCompleted => {
-            expect(taskCompleted).to.be.true;
-            cy.makeOfferAndConfirmTransaction();
-          });
+          cy.makeOfferAndConfirmTransaction();
         });
       });
     });

--- a/tests/e2e/specs/keplr/keplr-spec.js
+++ b/tests/e2e/specs/keplr/keplr-spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable ui-testing/no-disabled-tests */
 describe('Keplr', () => {
   context('Test commands', () => {
-    it(`should complete Keplr connect with wallet, and confirm transaction after importing an existing wallet using 24 word phrase`, () => {
+    it(`should connect with wallet, and confirm transaction after importing an existing wallet using 24 word phrase`, () => {
       cy.setupWallet().then(setupFinished => {
         expect(setupFinished).to.be.true;
 
@@ -9,16 +9,12 @@ describe('Keplr', () => {
         cy.contains('Connect Wallet').click();
         cy.acceptAccess().then(taskCompleted => {
           expect(taskCompleted).to.be.true;
-
-          cy.contains('Make an Offer').click();
-          cy.confirmTransaction().then(taskCompleted => {
-            expect(taskCompleted).to.be.true;
-          });
+          cy.makeOfferAndConfirmTransaction();
         });
       });
     });
 
-    it(`should complete Keplr connect with wallet, and confirm transaction after creating a new wallet using 24 word phrase`, () => {
+    it(`should connect with wallet, and confirm transaction after creating a new wallet using 24 word phrase`, () => {
       cy.switchToExtensionRegistrationWindow().then(() => {
         cy.setupWallet(
           'orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology',
@@ -31,11 +27,7 @@ describe('Keplr', () => {
           cy.contains('Connect Wallet').click();
           cy.acceptAccess().then(taskCompleted => {
             expect(taskCompleted).to.be.true;
-
-            cy.contains('Make an Offer').click();
-            cy.confirmTransaction().then(taskCompleted => {
-              expect(taskCompleted).to.be.true;
-            });
+            cy.makeOfferAndConfirmTransaction();
           });
         });
       });

--- a/tests/e2e/specs/keplr/keplr-spec.js
+++ b/tests/e2e/specs/keplr/keplr-spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable ui-testing/no-disabled-tests */
 describe('Keplr', () => {
   context('Test commands', () => {
-    it(`should complete Keplr connect with wallet, and confirm transaction after importing an existing wallet using 24 word phrase`, () => {
+    it(`should complete Keplr connect with wallet, and confirm transaction after importing a wallet using 24 word phrase`, () => {
       cy.setupWallet().then(setupFinished => {
         expect(setupFinished).to.be.true;
 
@@ -13,29 +13,6 @@ describe('Keplr', () => {
           cy.contains('Make an Offer').click();
           cy.confirmTransaction().then(taskCompleted => {
             expect(taskCompleted).to.be.true;
-          });
-        });
-      });
-    });
-
-    it(`should complete Keplr connect with wallet, and confirm transaction after creating a new wallet using 24 word phrase`, () => {
-      cy.switchToExtensionRegistrationWindow().then(() => {
-        cy.setupWallet(
-          'orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology',
-          'Test1234',
-          true,
-        ).then(setupFinished => {
-          expect(setupFinished).to.be.true;
-
-          cy.visit('/');
-          cy.contains('Connect Wallet').click();
-          cy.acceptAccess().then(taskCompleted => {
-            expect(taskCompleted).to.be.true;
-
-            cy.contains('Make an Offer').click();
-            cy.confirmTransaction().then(taskCompleted => {
-              expect(taskCompleted).to.be.true;
-            });
           });
         });
       });

--- a/tests/e2e/specs/keplr/keplr-spec.js
+++ b/tests/e2e/specs/keplr/keplr-spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable ui-testing/no-disabled-tests */
 describe('Keplr', () => {
   context('Test commands', () => {
-    it(`should complete Keplr connect with wallet, and confirm transaction after importing a wallet using 24 word phrase`, () => {
+    it(`should complete Keplr connect with wallet, and confirm transaction after importing an existing wallet using 24 word phrase`, () => {
       cy.setupWallet().then(setupFinished => {
         expect(setupFinished).to.be.true;
 
@@ -13,6 +13,29 @@ describe('Keplr', () => {
           cy.contains('Make an Offer').click();
           cy.confirmTransaction().then(taskCompleted => {
             expect(taskCompleted).to.be.true;
+          });
+        });
+      });
+    });
+
+    it(`should complete Keplr connect with wallet, and confirm transaction after creating a new wallet using 24 word phrase`, () => {
+      cy.switchToExtensionRegistrationWindow().then(() => {
+        cy.setupWallet(
+          'orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology',
+          'Test1234',
+          true,
+        ).then(setupFinished => {
+          expect(setupFinished).to.be.true;
+
+          cy.visit('/');
+          cy.contains('Connect Wallet').click();
+          cy.acceptAccess().then(taskCompleted => {
+            expect(taskCompleted).to.be.true;
+
+            cy.contains('Make an Offer').click();
+            cy.confirmTransaction().then(taskCompleted => {
+              expect(taskCompleted).to.be.true;
+            });
           });
         });
       });

--- a/tests/e2e/specs/keplr/keplr-spec.js
+++ b/tests/e2e/specs/keplr/keplr-spec.js
@@ -1,30 +1,54 @@
 /* eslint-disable ui-testing/no-disabled-tests */
 describe('Keplr', () => {
-    context('Test commands', () => {
-      it(`setupWallet should finish Keplr setup using secret words`, () => {
-        cy.setupWallet().then(setupFinished => {
-          expect(setupFinished).to.be.true;
-        });
-      });
-  
-      it(`acceptAccess should accept connection request to Keplr`, () => {
+  context('Test commands', () => {
+    it(`should complete Keplr connect with wallet, and confirm transaction after importing an existing wallet using 24 word phrase`, () => {
+      cy.setupWallet().then(setupFinished => {
+        expect(setupFinished).to.be.true;
+
         cy.visit('/');
         cy.contains('Connect Wallet').click();
         cy.acceptAccess().then(taskCompleted => {
           expect(taskCompleted).to.be.true;
+
+          cy.contains('Make an Offer').click();
+          cy.confirmTransaction().then(taskCompleted => {
+            expect(taskCompleted).to.be.true;
+          });
         });
-        cy.get('.card')
-          .contains('My Wallet')
-          .then(p => console.log(p));
-  
-        cy.contains('agoric1p2aqakv3ulz4qfy2nut86j9gx0dx0yw09h96md');
       });
-  
-      it(`confirmTransaction should confirm transaction for token creation (contract deployment) and check tx data`, () => {
-        cy.contains('Make an Offer').click();
-        cy.confirmTransaction().then(taskCompleted => {
-          expect(taskCompleted).to.be.true;
+    });
+
+    it(`should complete Keplr connect with wallet, and confirm transaction after creating a new wallet using 24 word phrase`, () => {
+      cy.switchToExtensionRegistrationWindow().then(() => {
+        cy.setupWallet(
+          'orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology',
+          'Test1234',
+          true,
+        ).then(setupFinished => {
+          expect(setupFinished).to.be.true;
+
+          cy.visit('/');
+          cy.contains('Connect Wallet').click();
+          cy.acceptAccess().then(taskCompleted => {
+            expect(taskCompleted).to.be.true;
+
+            cy.contains('Make an Offer').click();
+            cy.confirmTransaction().then(taskCompleted => {
+              expect(taskCompleted).to.be.true;
+            });
+          });
+        });
+      });
+    });
+
+    it(`should complete Keplr setup by importing the wallet using private key`, () => {
+      cy.switchToExtensionRegistrationWindow().then(() => {
+        cy.setupWallet(
+          'A9C09B6E4AF70DE1F1B621CB1AA66CFD0B4AA977E4C18497C49132DD9E579485',
+        ).then(setupFinished => {
+          expect(setupFinished).to.be.true;
         });
       });
     });
   });
+});


### PR DESCRIPTION
The PR adds Kepler Interactions for:
- Creating a new Wallet using a Private Key. 
- Creating a new Wallet using an existing 24-word phrase. 

And it handles an edge case illustrated below:
Scenario:
Test Case 1: The user has to connect with the wallet. The user clicks the connect wallet button. Popups show and the user approves the connection. 
Test Case 2: The user is performing some operation. The user needs to connect to the wallet. The user clicks the connect wallet button. No popup shows ==> The user was already connected to the wallet as this happened in the first test case. 

The PR addresses this edge case and handles scenarios where the user is already connected to the wallet. 

