### PR TITLE
Single Screen Interaction, Approve Button Fix and Code Cleanup

### DIFF
--- a/commands/keplr.js
+++ b/commands/keplr.js
@@ -7,41 +7,76 @@ const {
 
 let extensionId;
 let extensionVersion;
+let registrationUrl;
+let permissionsUrl;
 
 const keplr = {
   async resetState() {
     log('Resetting state of keplr');
     extensionId = undefined;
     extensionVersion = undefined;
+    registrationUrl = undefined;
+    permissionsUrl = undefined;
   },
   extensionId: () => {
     return extensionId;
   },
   extensionUrls: () => {
     return {
-      extensionImportAccountUrl,
+      registrationUrl,
+      permissionsUrl,
     };
   },
-
+  async goTo(url) {
+    await Promise.all([
+      playwright.keplrWindow().waitForNavigation(),
+      playwright.keplrWindow().goto(url),
+    ]);
+    await playwright.waitUntilStable();
+  },
+  async goToRegistration() {
+    await module.exports.goTo(registrationUrl);
+  },
+  async goToPermissions() {
+    await module.exports.goTo(permissionsUrl);
+  },
+  async switchToKeplrIfNotActive() {
+    if (await playwright.isCypressWindowActive()) {
+      await playwright.switchToKeplrWindow();
+      switchBackToCypressWindow = true;
+    }
+    return switchBackToCypressWindow;
+  },
   async getExtensionDetails() {
     const keplrExtensionData = (await playwright.getExtensionsData()).keplr;
 
     extensionId = keplrExtensionData.id;
     extensionVersion = keplrExtensionData.version;
+    registrationUrl = `chrome-extension://${extensionId}/register.html`;
+    permissionsUrl = `chrome-extension://${extensionId}/popup.html#/setting/security/permission`;
 
     return {
       extensionId,
       extensionVersion,
+      registrationUrl,
+      permissionsUrl,
     };
   },
   async disconnectWalletFromDapp() {
+    await module.exports.goToPermissions();
     await playwright.waitAndClickByText(
       'Disconnect All',
-      playwright.keplrPermissionWindow(),
+      playwright.keplrWindow(),
     );
     return true;
   },
   async importWallet(secretWordsOrPrivateKey, password, newAccount) {
+    const keplrWindow = playwright.keplrWindow();
+    const currentUrl = await keplrWindow.url();
+    if (!currentUrl.includes('registr')) {
+      await module.exports.goToRegistration();
+    }
+
     await playwright.waitAndClickByText(
       newAccount
         ? onboardingElements.createWalletButton
@@ -112,12 +147,7 @@ const keplr = {
       await playwright.keplrWindow(),
     );
 
-    await playwright.waitAndClick(
-      onboardingElements.finishButton,
-      await playwright.keplrWindow(),
-      { dontWait: true },
-    );
-
+    await playwright.switchToCypressWindow();
     return true;
   },
   async importWalletWithPhrase(secretWords) {

--- a/commands/keplr.js
+++ b/commands/keplr.js
@@ -114,7 +114,7 @@ const keplr = {
       onboardingElements.walletName,
     );
 
-    const passwordFieldExists = await playwright.doesElementExist(
+    const passwordFieldExists = await playwright.waitForAndCheckElementExistence(
       onboardingElements.passwordInput,
     );
 

--- a/commands/keplr.js
+++ b/commands/keplr.js
@@ -9,6 +9,7 @@ let extensionId;
 let extensionVersion;
 let registrationUrl;
 let permissionsUrl;
+let switchBackToCypressWindow;
 
 const keplr = {
   async resetState() {
@@ -71,12 +72,7 @@ const keplr = {
     return true;
   },
   async importWallet(secretWordsOrPrivateKey, password, newAccount) {
-    const keplrWindow = playwright.keplrWindow();
-    const currentUrl = await keplrWindow.url();
-    if (!currentUrl.includes('registr')) {
-      await module.exports.goToRegistration();
-    }
-
+    await module.exports.goToRegistration();
     await playwright.waitAndClickByText(
       newAccount
         ? onboardingElements.createWalletButton

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -582,6 +582,7 @@ const metamask = {
     return true;
   },
   async disconnectWalletFromDapp() {
+    await playwright.switchToKeplrWindow();
     await switchToMetamaskIfNotActive();
     await playwright.waitAndClick(mainPageElements.optionsMenu.button);
     await playwright.waitAndClick(

--- a/commands/playwright-keplr.js
+++ b/commands/playwright-keplr.js
@@ -22,6 +22,9 @@ module.exports = {
     retries = 0;
     extensionsData = {};
   },
+  browser() {
+    return browser;
+  },
   mainWindow() {
     return mainWindow;
   },

--- a/commands/playwright-keplr.js
+++ b/commands/playwright-keplr.js
@@ -7,8 +7,6 @@ let browser;
 let mainWindow;
 let keplrWindow;
 let keplrNotificationWindow;
-let keplrRegistrationWindow;
-let keplrPermissionWindow;
 let activeTabName;
 let extensionsData = {};
 let retries = 0;
@@ -21,12 +19,50 @@ module.exports = {
     keplrWindow = undefined;
     activeTabName = undefined;
     keplrNotificationWindow = undefined;
-    keplrRegistrationWindow = undefined;
-    keplrPermissionWindow = undefined;
     retries = 0;
     extensionsData = {};
   },
-
+  mainWindow() {
+    return mainWindow;
+  },
+  keplrWindow() {
+    return keplrWindow;
+  },
+  keplrNotificationWindow() {
+    return keplrNotificationWindow;
+  },
+  async assignActiveTabName(tabName) {
+    activeTabName = tabName;
+    return true;
+  },
+  async isKeplrWindowActive() {
+    return activeTabName === 'keplr';
+  },
+  async isCypressWindowActive() {
+    return activeTabName === 'cypress';
+  },
+  async switchToKeplrWindow() {
+    await keplrWindow.bringToFront();
+    await module.exports.assignActiveTabName('keplr');
+    return true;
+  },
+  async switchToCypressWindow() {
+    if (mainWindow) {
+      await mainWindow.bringToFront();
+      await module.exports.assignActiveTabName('cypress');
+    }
+    return true;
+  },
+  async clear() {
+    browser = null;
+    return true;
+  },
+  async clearWindows() {
+    mainWindow = null;
+    keplrWindow = null;
+    keplrNotificationWindow = null;
+    return true;
+  },
   async init(playwrightInstance) {
     const chromium = playwrightInstance
       ? playwrightInstance
@@ -49,280 +85,6 @@ module.exports = {
     }
     return browser.isConnected();
   },
-
-  async assignWindows() {
-    const keplrExtensionData = (await module.exports.getExtensionsData()).keplr;
-
-    let pages = await browser.contexts()[0].pages();
-
-    for (const page of pages) {
-      if (page.url().includes('specs/runner')) {
-        mainWindow = page;
-      } else if (
-        page
-          .url()
-          .includes(`chrome-extension://${keplrExtensionData.id}/register.html`)
-      ) {
-        keplrWindow = page;
-      }
-    }
-    return true;
-  },
-  async assignActiveTabName(tabName) {
-    activeTabName = tabName;
-    return true;
-  },
-
-  async isKeplrWindowActive() {
-    return activeTabName === 'keplr';
-  },
-
-  keplrNotificationWindow() {
-    return keplrNotificationWindow;
-  },
-
-  keplrPermissionWindow() {
-    return keplrPermissionWindow;
-  },
-
-  async switchToKeplrPermissionWindow() {
-    const keplrExtensionData = (await module.exports.getExtensionsData()).keplr;
-    const browserContext = await browser.contexts()[0];
-    keplrPermissionWindow = await browserContext.newPage();
-    await keplrPermissionWindow.goto(
-      `chrome-extension://${keplrExtensionData.id}/popup.html#/setting/security/permission`,
-    );
-    return true;
-  },
-
-  async waitAndClickByText(text, page = keplrWindow, exact = false) {
-    await module.exports.waitForByText(text, page);
-    const element = `:is(:text-is("${text}")${exact ? '' : `, :text("${text}")`})`;
-    await page.click(element);
-    await module.exports.waitUntilStable();
-  },
-
-  async waitAndSetValue(text, selector, page = keplrWindow) {
-    const element = await module.exports.waitFor(selector, page);
-    await element.fill('');
-    await module.exports.waitUntilStable(page);
-    await element.fill(text);
-    await module.exports.waitUntilStable(page);
-  },
-
-  async waitAndGetValue(selector, page = keplrWindow) {
-    const expect = expectInstance
-      ? expectInstance
-      : require('@playwright/test').expect;
-    const element = await module.exports.waitFor(selector, page);
-    await expect(element).toHaveText(/[a-zA-Z0-9]/, {
-      ignoreCase: true,
-      useInnerText: true,
-    });
-    const value = await element.innerText();
-    return value;
-  },
-
-  async waitAndClick(selector, page = keplrWindow, args = {}) {
-    const element = await module.exports.waitFor(
-      selector,
-      page,
-      args.number || 0,
-    );
-    if (args.numberOfClicks && !args.waitForEvent) {
-      await element.click({
-        clickCount: args.numberOfClicks,
-        force: args.force,
-      });
-    } else if (args.numberOfClicks && args.waitForEvent) {
-      await Promise.all([
-        page.waitForEvent(args.waitForEvent),
-        element.click({ clickCount: args.numberOfClicks, force: args.force }),
-      ]);
-    } else if (args.waitForEvent) {
-      if (args.waitForEvent.includes('navi')) {
-        await Promise.all([
-          page.waitForNavigation(),
-          element.click({ force: args.force }),
-        ]);
-      } else {
-        await Promise.all([
-          page.waitForEvent(args.waitForEvent),
-          element.click({ force: args.force }),
-        ]);
-      }
-    } else {
-      await element.click({ force: args.force });
-    }
-    await module.exports.waitUntilStable();
-    return element;
-  },
-
-  async switchToCypressWindow() {
-    if (mainWindow) {
-      await mainWindow.bringToFront();
-      await module.exports.assignActiveTabName('cypress');
-    }
-    return true;
-  },
-
-  async clear() {
-    browser = null;
-    return true;
-  },
-
-  async clearWindows() {
-    mainWindow = null;
-    keplrWindow = null;
-    return true;
-  },
-
-  async isCypressWindowActive() {
-    return activeTabName === 'cypress';
-  },
-
-  async switchToKeplrWindow() {
-    await keplrWindow.bringToFront();
-    await module.exports.assignActiveTabName('keplr');
-    return true;
-  },
-
-  async waitUntilStable(page) {
-    const keplrExtensionData = (await module.exports.getExtensionsData()).keplr;
-
-    if (
-      page &&
-      page
-        .url()
-        .includes(`chrome-extension://${keplrExtensionData.id}/register.html`)
-    ) {
-      await page.waitForLoadState('load');
-      await page.waitForLoadState('domcontentloaded');
-      await page.waitForLoadState('networkidle');
-    }
-    await keplrWindow.waitForLoadState('load');
-    await keplrWindow.waitForLoadState('domcontentloaded');
-    await keplrWindow.waitForLoadState('networkidle');
-
-    if (mainWindow) {
-      await mainWindow.waitForLoadState('load');
-      await mainWindow.waitForLoadState('domcontentloaded');
-      // todo: this may slow down tests and not be necessary but could improve stability
-      // await mainWindow.waitForLoadState('networkidle');
-    }
-  },
-
-  keplrWindow() {
-    return keplrWindow;
-  },
-
-  async waitFor(selector, page = keplrWindow, number = 0) {
-    await module.exports.waitUntilStable(page);
-    await page.waitForSelector(selector, { strict: false });
-    const element = page.locator(selector).nth(number);
-    await element.waitFor();
-    await element.focus();
-    if (process.env.STABLE_MODE) {
-      if (!isNaN(process.env.STABLE_MODE)) {
-        await page.waitForTimeout(Number(process.env.STABLE_MODE));
-      } else {
-        await page.waitForTimeout(300);
-      }
-    }
-    return element;
-  },
-  async doesElementExist(selector, timeout = 1000, page = keplrWindow) {
-    try {
-      await page.waitForSelector(selector, { timeout });
-      return true;
-    } catch (error) {
-      return false;
-    }
-  },
-  async waitForByText(text, page = keplrWindow) {
-    await module.exports.waitUntilStable(page);
-    // await page.waitForSelector(selector, { strict: false });
-    const element = page.getByText(text).first();
-    await element.waitFor();
-    await element.focus();
-    if (process.env.STABLE_MODE) {
-      if (!isNaN(process.env.STABLE_MODE)) {
-        await page.waitForTimeout(Number(process.env.STABLE_MODE));
-      } else {
-        await page.waitForTimeout(300);
-      }
-    }
-    return element;
-  },
-
-  async waitAndClick(selector, page = keplrWindow, args = {}) {
-    const element = await module.exports.waitFor(
-      selector,
-      page,
-      args.number || 0,
-    );
-    if (args.numberOfClicks && !args.waitForEvent) {
-      await element.click({
-        clickCount: args.numberOfClicks,
-        force: args.force,
-      });
-    } else if (args.numberOfClicks && args.waitForEvent) {
-      await Promise.all([
-        page.waitForEvent(args.waitForEvent),
-        element.click({ clickCount: args.numberOfClicks, force: args.force }),
-      ]);
-    } else if (args.waitForEvent) {
-      if (args.waitForEvent.includes('navi')) {
-        await Promise.all([
-          page.waitForNavigation(),
-          element.click({ force: args.force }),
-        ]);
-      } else {
-        await Promise.all([
-          page.waitForEvent(args.waitForEvent),
-          element.click({ force: args.force }),
-        ]);
-      }
-    } else {
-      await element.click({ force: args.force });
-    }
-    await module.exports.waitUntilStable();
-    return element;
-  },
-
-  async waitForByRole(role, number = 0, page = keplrWindow) {
-    await module.exports.waitUntilStable(page);
-    const element = page.getByRole(role).nth(number);
-    await element.waitFor();
-    await element.focus();
-    if (process.env.STABLE_MODE) {
-      if (!isNaN(process.env.STABLE_MODE)) {
-        await page.waitForTimeout(Number(process.env.STABLE_MODE));
-      } else {
-        await page.waitForTimeout(300);
-      }
-    }
-    return element;
-  },
-
-  async waitAndType(selector, value, page = keplrWindow) {
-    if (typeof value === 'number') {
-      value = value.toString();
-    }
-    const element = await module.exports.waitFor(selector, page);
-    await element.type(value);
-    await module.exports.waitUntilStable(page);
-  },
-
-  async waitAndTypeByLocator(selector, value, number = 0, page = keplrWindow) {
-    if (typeof value === 'number') {
-      value = value.toString();
-    }
-    const element = await module.exports.waitForByRole(selector, number, page);
-    await element.type(value);
-    await module.exports.waitUntilStable(page);
-  },
-
   async getExtensionsData() {
     if (!_.isEmpty(extensionsData)) {
       return extensionsData;
@@ -369,15 +131,206 @@ module.exports = {
 
     return extensionsData;
   },
-
-  async switchToKeplrRegistrationWindow() {
+  async assignWindows() {
     const keplrExtensionData = (await module.exports.getExtensionsData()).keplr;
-    const browserContext = await browser.contexts()[0];
-    keplrRegistrationWindow = await browserContext.newPage();
-    await keplrRegistrationWindow.goto(
-      `chrome-extension://${keplrExtensionData.id}/register.html`,
-    );
+
+    let pages = await browser.contexts()[0].pages();
+
+    for (const page of pages) {
+      if (page.url().includes('specs/runner')) {
+        mainWindow = page;
+      } else if (
+        page
+          .url()
+          .includes(`chrome-extension://${keplrExtensionData.id}/register.html`)
+      ) {
+        keplrWindow = page;
+      }
+    }
     return true;
+  },
+  async waitUntilStable(page) {
+    const keplrExtensionData = (await module.exports.getExtensionsData()).keplr;
+    if (
+      page &&
+      page
+        .url()
+        .includes(`chrome-extension://${keplrExtensionData.id}/register.html`)
+    ) {
+      await page.waitForLoadState('load');
+      await page.waitForLoadState('domcontentloaded');
+      await page.waitForLoadState('networkidle');
+    }
+    await keplrWindow.waitForLoadState('load');
+    await keplrWindow.waitForLoadState('domcontentloaded');
+    await keplrWindow.waitForLoadState('networkidle');
+
+    if (mainWindow) {
+      await mainWindow.waitForLoadState('load');
+      await mainWindow.waitForLoadState('domcontentloaded');
+      // todo: this may slow down tests and not be necessary but could improve stability
+      // await mainWindow.waitForLoadState('networkidle');
+    }
+  },
+  async waitFor(selector, page = keplrWindow, number = 0) {
+    await module.exports.waitUntilStable(page);
+    await page.waitForSelector(selector, { strict: false });
+    const element = page.locator(selector).nth(number);
+    await element.waitFor();
+    await element.focus();
+    if (process.env.STABLE_MODE) {
+      if (!isNaN(process.env.STABLE_MODE)) {
+        await page.waitForTimeout(Number(process.env.STABLE_MODE));
+      } else {
+        await page.waitForTimeout(300);
+      }
+    }
+    return element;
+  },
+  async waitForByText(text, page = keplrWindow) {
+    await module.exports.waitUntilStable(page);
+    const element = page.getByText(text).first();
+    await element.waitFor();
+    await element.focus();
+    if (process.env.STABLE_MODE) {
+      if (!isNaN(process.env.STABLE_MODE)) {
+        await page.waitForTimeout(Number(process.env.STABLE_MODE));
+      } else {
+        await page.waitForTimeout(300);
+      }
+    }
+    return element;
+  },
+  async waitAndClickByText(text, page = keplrWindow, exact = false) {
+    await module.exports.waitForByText(text, page);
+    const element = `:is(:text-is("${text}")${exact ? '' : `, :text("${text}")`})`;
+    await page.click(element);
+    await module.exports.waitUntilStable();
+  },
+  async waitAndSetValue(text, selector, page = keplrWindow) {
+    const element = await module.exports.waitFor(selector, page);
+    await element.fill('');
+    await module.exports.waitUntilStable(page);
+    await element.fill(text);
+    await module.exports.waitUntilStable(page);
+  },
+  async waitAndGetValue(selector, page = keplrWindow) {
+    const expect = expectInstance
+      ? expectInstance
+      : require('@playwright/test').expect;
+    const element = await module.exports.waitFor(selector, page);
+    await expect(element).toHaveText(/[a-zA-Z0-9]/, {
+      ignoreCase: true,
+      useInnerText: true,
+    });
+    const value = await element.innerText();
+    return value;
+  },
+  async waitAndClick(selector, page = keplrWindow, args = {}) {
+    const element = await module.exports.waitFor(
+      selector,
+      page,
+      args.number || 0,
+    );
+    if (args.numberOfClicks && !args.waitForEvent) {
+      await element.click({
+        clickCount: args.numberOfClicks,
+        force: args.force,
+      });
+    } else if (args.numberOfClicks && args.waitForEvent) {
+      await Promise.all([
+        page.waitForEvent(args.waitForEvent),
+        element.click({ clickCount: args.numberOfClicks, force: args.force }),
+      ]);
+    } else if (args.waitForEvent) {
+      if (args.waitForEvent.includes('navi')) {
+        await Promise.all([
+          page.waitForNavigation(),
+          element.click({ force: args.force }),
+        ]);
+      } else {
+        await Promise.all([
+          page.waitForEvent(args.waitForEvent),
+          element.click({ force: args.force }),
+        ]);
+      }
+    } else {
+      await element.click({ force: args.force });
+    }
+    await module.exports.waitUntilStable();
+    return element;
+  },
+  async doesElementExist(selector, timeout = 1000, page = keplrWindow) {
+    try {
+      await page.waitForSelector(selector, { timeout });
+      return true;
+    } catch (error) {
+      return false;
+    }
+  },
+  async waitAndClick(selector, page = keplrWindow, args = {}) {
+    const element = await module.exports.waitFor(
+      selector,
+      page,
+      args.number || 0,
+    );
+    if (args.numberOfClicks && !args.waitForEvent) {
+      await element.click({
+        clickCount: args.numberOfClicks,
+        force: args.force,
+      });
+    } else if (args.numberOfClicks && args.waitForEvent) {
+      await Promise.all([
+        page.waitForEvent(args.waitForEvent),
+        element.click({ clickCount: args.numberOfClicks, force: args.force }),
+      ]);
+    } else if (args.waitForEvent) {
+      if (args.waitForEvent.includes('navi')) {
+        await Promise.all([
+          page.waitForNavigation(),
+          element.click({ force: args.force }),
+        ]);
+      } else {
+        await Promise.all([
+          page.waitForEvent(args.waitForEvent),
+          element.click({ force: args.force }),
+        ]);
+      }
+    } else {
+      await element.click({ force: args.force });
+    }
+    await module.exports.waitUntilStable();
+    return element;
+  },
+  async waitForByRole(role, number = 0, page = keplrWindow) {
+    await module.exports.waitUntilStable(page);
+    const element = page.getByRole(role).nth(number);
+    await element.waitFor();
+    await element.focus();
+    if (process.env.STABLE_MODE) {
+      if (!isNaN(process.env.STABLE_MODE)) {
+        await page.waitForTimeout(Number(process.env.STABLE_MODE));
+      } else {
+        await page.waitForTimeout(300);
+      }
+    }
+    return element;
+  },
+  async waitAndType(selector, value, page = keplrWindow) {
+    if (typeof value === 'number') {
+      value = value.toString();
+    }
+    const element = await module.exports.waitFor(selector, page);
+    await element.type(value);
+    await module.exports.waitUntilStable(page);
+  },
+  async waitAndTypeByLocator(selector, value, number = 0, page = keplrWindow) {
+    if (typeof value === 'number') {
+      value = value.toString();
+    }
+    const element = await module.exports.waitForByRole(selector, number, page);
+    await element.type(value);
+    await module.exports.waitUntilStable(page);
   },
   async switchToKeplrNotification() {
     const keplrExtensionData = (await module.exports.getExtensionsData()).keplr;

--- a/commands/playwright-keplr.js
+++ b/commands/playwright-keplr.js
@@ -263,7 +263,7 @@ module.exports = {
     await module.exports.waitUntilStable();
     return element;
   },
-  async doesElementExist(selector, timeout = 1000, page = keplrWindow) {
+  async waitForAndCheckElementExistence(selector, timeout = 1000, page = keplrWindow) {
     try {
       await page.waitForSelector(selector, { timeout });
       return true;

--- a/pages/keplr/notification-page.js
+++ b/pages/keplr/notification-page.js
@@ -1,4 +1,4 @@
-const approveButton = `button[type="button"]`;
+const approveButton = `button`;
 
 module.exports.notificationPageElements = {
   approveButton,

--- a/support/commands.js
+++ b/support/commands.js
@@ -445,14 +445,6 @@ Cypress.Commands.add('switchToExtensionWindow', () => {
   return cy.task('switchToExtensionWindow');
 });
 
-Cypress.Commands.add('switchToExtensionRegistrationWindow', () => {
-  return cy.task('switchToExtensionRegistrationWindow');
-});
-
-Cypress.Commands.add('switchToExtensionPermissionWindow', () => {
-  return cy.task('switchToExtensionPermissionWindow');
-});
-
 Cypress.Commands.add('disconnectWalletFromDapp', () => {
   return cy.task('disconnectWalletFromDapp');
 });

--- a/tests/e2e/specs/keplr/keplr-spec.js
+++ b/tests/e2e/specs/keplr/keplr-spec.js
@@ -61,10 +61,8 @@ describe('Keplr', () => {
       });
     });
     it(`should disconnect the wallet from all the connected DAPPs`, () => {
-      cy.switchToExtensionWindow().then(() => {
-        cy.disconnectWalletFromDapp().then(taskCompleted => {
-          expect(taskCompleted).to.be.true;
-        });
+      cy.disconnectWalletFromDapp().then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
       });
     });
   });

--- a/tests/e2e/specs/keplr/keplr-spec.js
+++ b/tests/e2e/specs/keplr/keplr-spec.js
@@ -7,7 +7,7 @@ describe('Keplr', () => {
       });
       cy.visit('/');
     });
-    it(`should reject connect with wallet`, () => {
+    it(`should reject connection with wallet`, () => {
       const alertShown = cy.stub().as('alertShown');
       cy.on('window:alert', alertShown);
 
@@ -40,39 +40,30 @@ describe('Keplr', () => {
         'Offer accepted',
       );
     });
-    it(`should complete Keplr connect with wallet, and confirm transaction after creating a new wallet using 24 word phrase`, () => {
-      cy.switchToExtensionRegistrationWindow().then(() => {
+    it(`should create a new wallet using 24 word phrase`, () => {
+      cy.switchToExtensionWindow().then(() => {
         cy.setupWallet(
           'orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology',
           'Test1234',
           true,
         ).then(setupFinished => {
           expect(setupFinished).to.be.true;
-
-          cy.visit('/');
-          cy.contains('Connect Wallet').click();
-          cy.contains('Make an Offer').click();
-          cy.confirmTransaction().then(taskCompleted => {
-            expect(taskCompleted).to.be.true;
-          });
         });
       });
     });
-
-    it(`should disconnect the wallet from all the connected DAPPs`, () => {
-      cy.switchToExtensionPermissionWindow().then(() => {
-        cy.disconnectWalletFromDapp().then(taskCompleted => {
-          expect(taskCompleted).to.be.true;
-        });
-      });
-    });
-
     it(`should complete Keplr setup by importing the wallet using private key`, () => {
-      cy.switchToExtensionRegistrationWindow().then(() => {
+      cy.switchToExtensionWindow().then(() => {
         cy.setupWallet(
           'A9C09B6E4AF70DE1F1B621CB1AA66CFD0B4AA977E4C18497C49132DD9E579485',
         ).then(setupFinished => {
           expect(setupFinished).to.be.true;
+        });
+      });
+    });
+    it(`should disconnect the wallet from all the connected DAPPs`, () => {
+      cy.switchToExtensionWindow().then(() => {
+        cy.disconnectWalletFromDapp().then(taskCompleted => {
+          expect(taskCompleted).to.be.true;
         });
       });
     });

--- a/tests/e2e/specs/keplr/playwright-spec.js
+++ b/tests/e2e/specs/keplr/playwright-spec.js
@@ -28,5 +28,14 @@ describe('Playwright', () => {
           expect(isActive).to.be.false;
         });
       });
+      it(`switchToExtensionWindow should properly switch active tab to keplr window`, () => {
+        cy.switchToExtensionWindow();
+        cy.isExtensionWindowActive().then(isActive => {
+          expect(isActive).to.be.true;
+        });
+        cy.isCypressWindowActive().then(isActive => {
+          expect(isActive).to.be.false;
+        });
+      });
     });
   });


### PR DESCRIPTION
The PR does the following:
- Organizes code and eliminates not-required states in `playwright-keplr.js`. 
- Adds the functionality of using a single extension screen for interaction with Keplr. This behaviour allows us to open a dedicated tab whenever we interact with Keplr. 
- Resolves the issue of the `Approve` button not being able to be clicked when we disconnected the wallet. 