### PR TITLE
Enable setup of the keplr extension in the beforeAll hook for cypress

### DIFF
--- a/plugins/index.js
+++ b/plugins/index.js
@@ -9,11 +9,15 @@ module.exports = (on, config) => {
     throw new Error(`${extension} is not a valid extension name`);
   }
 
-  if (process.env.SKIP_EXTENSION_SETUP)
+  if (process.env.SKIP_EXTENSION_SETUP) {
     config.env.SKIP_EXTENSION_SETUP = JSON.parse(
       process.env.SKIP_EXTENSION_SETUP,
     );
-  if (process.env.EXTENSION) config.env.EXTENSION = process.env.EXTENSION;
+  }
+
+  if (process.env.EXTENSION) {
+    config.env.EXTENSION = process.env.EXTENSION;
+  }
 
   return selectedConfig(on, config);
 };

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -6,10 +6,14 @@ module.exports = (on, config) => {
   } else if (extension === 'keplr') {
     selectedConfig = require('./keplr-plugin');
   } else {
-    throw new Error(
-      `${extension} is not a valid extension name`,
-    );
+    throw new Error(`${extension} is not a valid extension name`);
   }
+
+  if (process.env.SKIP_EXTENSION_SETUP)
+    config.env.SKIP_EXTENSION_SETUP = JSON.parse(
+      process.env.SKIP_EXTENSION_SETUP,
+    );
+  if (process.env.EXTENSION) config.env.EXTENSION = process.env.EXTENSION;
 
   return selectedConfig(on, config);
 };

--- a/support/index.js
+++ b/support/index.js
@@ -25,7 +25,16 @@ Cypress.on('window:before:load', win => {
 });
 
 before(() => {
-  if (Cypress.env('EXTENSION') === 'metamask' && !Cypress.env('SKIP_EXTENSION_SETUP')) {
-    cy.setupMetamask();
+  if (!Cypress.env('SKIP_EXTENSION_SETUP')) {
+    switch (Cypress.env('EXTENSION')) {
+      case 'metamask':
+        cy.setupMetamask();
+        break;
+      case 'keplr':
+        cy.setupWallet();
+        break;
+      default:
+        throw new Error(`Unknown extension: ${Cypress.env('EXTENSION')}`);
+    }
   }
 });

--- a/support/index.js
+++ b/support/index.js
@@ -33,8 +33,6 @@ before(() => {
       case 'keplr':
         cy.setupWallet();
         break;
-      default:
-        throw new Error(`Unknown extension: ${Cypress.env('EXTENSION')}`);
     }
   }
 });


### PR DESCRIPTION
## Motivation and context

This PR enables the framework to automatically setup the keplr extension, even if the user doesn't explicitly do it themselves.
