### PR TITLE
Remove call to switchToKeplrWindow 

### DIFF
--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -582,7 +582,6 @@ const metamask = {
     return true;
   },
   async disconnectWalletFromDapp() {
-    await playwright.switchToKeplrWindow();
     await switchToMetamaskIfNotActive();
     await playwright.waitAndClick(mainPageElements.optionsMenu.button);
     await playwright.waitAndClick(


### PR DESCRIPTION
The PR removes a not required call to `switchToKeplrWindow` in the `metamask.js` file. 