### PR TITLE
Add command to switch to another wallet

### DIFF
--- a/commands/keplr.js
+++ b/commands/keplr.js
@@ -9,6 +9,7 @@ let extensionId;
 let extensionVersion;
 let registrationUrl;
 let permissionsUrl;
+let walletsPageUrl;
 let switchBackToCypressWindow;
 
 const keplr = {
@@ -18,6 +19,7 @@ const keplr = {
     extensionVersion = undefined;
     registrationUrl = undefined;
     permissionsUrl = undefined;
+    walletsPageUrl = undefined;
   },
   extensionId: () => {
     return extensionId;
@@ -41,6 +43,9 @@ const keplr = {
   async goToPermissions() {
     await module.exports.goTo(permissionsUrl);
   },
+  async goToWalletsPage() {
+    await module.exports.goTo(walletsPageUrl);
+  },
   async switchToKeplrIfNotActive() {
     if (playwright.isCypressWindowActive()) {
       await playwright.switchToKeplrWindow();
@@ -55,12 +60,14 @@ const keplr = {
     extensionVersion = keplrExtensionData.version;
     registrationUrl = `chrome-extension://${extensionId}/register.html`;
     permissionsUrl = `chrome-extension://${extensionId}/popup.html#/setting/security/permission`;
+    walletsPageUrl = `chrome-extension://${extensionId}/popup.html#/wallet/select`;
 
     return {
       extensionId,
       extensionVersion,
       registrationUrl,
       permissionsUrl,
+      walletsPageUrl,
     };
   },
   async disconnectWalletFromDapp() {
@@ -71,7 +78,12 @@ const keplr = {
     );
     return true;
   },
-  async importWallet(secretWordsOrPrivateKey, password, newAccount) {
+  async importWallet(
+    secretWordsOrPrivateKey,
+    password,
+    newAccount,
+    walletName,
+  ) {
     await module.exports.goToRegistration();
     await playwright.waitAndClickByText(
       newAccount
@@ -105,14 +117,12 @@ const keplr = {
       );
     }
 
-    await playwright.waitAndType(
-      onboardingElements.walletInput,
-      onboardingElements.walletName,
-    );
+    await playwright.waitAndType(onboardingElements.walletInput, walletName);
 
-    const passwordFieldExists = await playwright.waitForAndCheckElementExistence(
-      onboardingElements.passwordInput,
-    );
+    const passwordFieldExists =
+      await playwright.waitForAndCheckElementExistence(
+        onboardingElements.passwordInput,
+      );
 
     if (passwordFieldExists) {
       await playwright.waitAndType(onboardingElements.passwordInput, password);
@@ -216,7 +226,7 @@ const keplr = {
 
   async initialSetup(
     playwrightInstance,
-    { secretWordsOrPrivateKey, password, newAccount },
+    { secretWordsOrPrivateKey, password, newAccount, walletName },
   ) {
     if (playwrightInstance) {
       await playwright.init(playwrightInstance);
@@ -234,7 +244,22 @@ const keplr = {
       secretWordsOrPrivateKey,
       password,
       newAccount,
+      walletName,
     );
+  },
+
+  async switchWallet({ walletName }) {
+    await module.exports.switchToKeplrIfNotActive();
+    module.exports.goToWalletsPage();
+
+    await playwright.waitAndClickByText(
+      walletName,
+      await playwright.keplrWindow(),
+      true,
+    );
+    await playwright.switchToCypressWindow();
+
+    return true;
   },
 };
 

--- a/commands/keplr.js
+++ b/commands/keplr.js
@@ -250,11 +250,11 @@ const keplr = {
 
   async switchWallet({ walletName }) {
     await module.exports.switchToKeplrIfNotActive();
-    module.exports.goToWalletsPage();
+    await module.exports.goToWalletsPage();
 
     await playwright.waitAndClickByText(
       walletName,
-      await playwright.keplrWindow(),
+      playwright.keplrWindow(),
       true,
     );
     await playwright.switchToCypressWindow();

--- a/pages/keplr/first-time-flow-page.js
+++ b/pages/keplr/first-time-flow-page.js
@@ -1,13 +1,12 @@
 const createWalletButton = 'Create a new wallet';
 const existingWalletButton = 'Import an existing wallet';
-const importRecoveryPhraseButton = 'Import existing recovery phrase'; 
+const importRecoveryPhraseButton = 'Import existing recovery phrase';
 const useRecoveryPhraseButton = 'Use recovery phrase or private key';
 const phraseCount24 = '24 words';
 const phrasePrivateKey = 'Private key';
 const walletInput = 'input[name="name"]:focus';
 const passwordInput = 'input[name="password"]';
 const confirmPasswordInput = 'input[name="confirmPassword"]';
-const walletName = 'My wallet';
 const submitWalletDataButton = 'button[type="submit"]';
 const phraseSelectChain = 'Select Chains';
 const submitChainButton = 'button[type="button"]';
@@ -24,7 +23,6 @@ module.exports.onboardingElements = {
   phraseCount24,
   phrasePrivateKey,
   walletInput,
-  walletName,
   passwordInput,
   confirmPasswordInput,
   submitWalletDataButton,
@@ -33,6 +31,5 @@ module.exports.onboardingElements = {
   phraseAccountCreated,
   finishButton,
   textAreaSelector,
-  submitChainButton,
   submitPhraseButton,
 };

--- a/plugins/keplr-plugin.js
+++ b/plugins/keplr-plugin.js
@@ -71,14 +71,21 @@ module.exports = (on, config) => {
     confirmTransaction: keplr.confirmTransaction,
     rejectTransaction: keplr.rejectTransaction,
     disconnectWalletFromDapp: keplr.disconnectWalletFromDapp,
-    setupWallet: async ({ secretWordsOrPrivateKey, password, newAccount }) => {
+    setupWallet: async ({
+      secretWordsOrPrivateKey,
+      password,
+      newAccount,
+      walletName,
+    }) => {
       await keplr.initialSetup(null, {
         secretWordsOrPrivateKey,
         password,
         newAccount,
+        walletName,
       });
       return true;
     },
+    switchWallet: keplr.switchWallet,
   });
 
   return config;

--- a/support/commands.js
+++ b/support/commands.js
@@ -416,11 +416,13 @@ Cypress.Commands.add(
     secretWordsOrPrivateKey = 'orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology',
     password = 'Test1234',
     newAccount = false,
+    walletName = 'My Wallet',
   ) => {
     return cy.task('setupWallet', {
       secretWordsOrPrivateKey,
       password,
       newAccount,
+      walletName,
     });
   },
 );
@@ -451,4 +453,8 @@ Cypress.Commands.add('switchToExtensionWindow', () => {
 
 Cypress.Commands.add('disconnectWalletFromDapp', () => {
   return cy.task('disconnectWalletFromDapp');
+});
+
+Cypress.Commands.add('switchWallet', walletName => {
+  return cy.task('switchWallet', { walletName });
 });

--- a/tests/e2e/specs/keplr/keplr-spec.js
+++ b/tests/e2e/specs/keplr/keplr-spec.js
@@ -59,6 +59,7 @@ describe('Keplr', () => {
         'orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology',
         'Test1234',
         true,
+        'My Wallet 2',
       ).then(setupFinished => {
         expect(setupFinished).to.be.true;
       });
@@ -66,9 +67,17 @@ describe('Keplr', () => {
     it(`should complete Keplr setup by importing the wallet using private key`, () => {
       cy.setupWallet(
         'A9C09B6E4AF70DE1F1B621CB1AA66CFD0B4AA977E4C18497C49132DD9E579485',
+        false,
+        'My wallet 3',
       ).then(setupFinished => {
         expect(setupFinished).to.be.true;
       });
+    });
+    it(`should switch to new wallet by name`, () => {
+      cy.switchWallet('My Wallet 2').then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
+      // TODO: Add some more robust check later
     });
     it(`should disconnect the wallet from all the connected DAPPs`, () => {
       cy.disconnectWalletFromDapp().then(taskCompleted => {

--- a/tests/e2e/specs/keplr/keplr-spec.js
+++ b/tests/e2e/specs/keplr/keplr-spec.js
@@ -67,6 +67,7 @@ describe('Keplr', () => {
     it(`should complete Keplr setup by importing the wallet using private key`, () => {
       cy.setupWallet(
         'A9C09B6E4AF70DE1F1B621CB1AA66CFD0B4AA977E4C18497C49132DD9E579485',
+        null,
         false,
         'My wallet 3',
       ).then(setupFinished => {


### PR DESCRIPTION
## Motivation and context

This PR adds the functions and the test cases to allow synpress to switch to another keplr wallet by its name
