### PR TITLE
Changed args style for setupWallet command

### DIFF
--- a/support/commands.js
+++ b/support/commands.js
@@ -410,22 +410,24 @@ Cypress.Commands.add(
 );
 
 // Keplr Commands
-Cypress.Commands.add(
-  'setupWallet',
-  (
-    secretWordsOrPrivateKey = 'orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology',
+Cypress.Commands.add('setupWallet', (args = {}) => {
+  const {
+    secretWords,
+    privateKey,
     password = 'Test1234',
     newAccount = false,
     walletName = 'My Wallet',
-  ) => {
-    return cy.task('setupWallet', {
-      secretWordsOrPrivateKey,
-      password,
-      newAccount,
-      walletName,
-    });
-  },
-);
+  } = args;
+  return cy.task('setupWallet', {
+    secretWordsOrPrivateKey:
+      secretWords ||
+      privateKey ||
+      'orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology',
+    password,
+    newAccount,
+    walletName,
+  });
+});
 
 Cypress.Commands.add('acceptAccess', () => {
   return cy.task('acceptAccess');

--- a/support/index.d.ts
+++ b/support/index.d.ts
@@ -505,5 +505,23 @@ declare namespace Cypress {
       viewportWidth: number,
       viewportHeight: number,
     ): Chainable<Subject>;
+    /**
+     * Generic method to setup wallet (works for keplr only)
+     * @example
+     * cy.setupWallet();
+     * cy.setupWallet({
+     *   secretWords: 'test test test test test test test test test test test junk',
+     *   password: 'Password123',
+     * });
+     */
+    setupWallet(
+      args: {
+        secretWords?: String;
+        privateKey?: String;
+        password?: String;
+        newAccount?: Boolean;
+        walletName?: String;
+      }
+    ): Chainable<Subject>;
   }
 }

--- a/tests/e2e/specs/keplr/keplr-spec.js
+++ b/tests/e2e/specs/keplr/keplr-spec.js
@@ -56,22 +56,22 @@ describe('Keplr', () => {
       );
     });
     it(`should create a new wallet using 24 word phrase`, () => {
-      cy.setupWallet(
-        'orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology',
-        'Test1234',
-        true,
-        'My Wallet 2',
-      ).then(setupFinished => {
+      cy.setupWallet({
+        secretWords:
+          'orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology',
+        password: 'Test1234',
+        newAccount: true,
+        walletName: 'My Wallet 2',
+      }).then(setupFinished => {
         expect(setupFinished).to.be.true;
       });
     });
     it(`should complete Keplr setup by importing the wallet using private key`, () => {
-      cy.setupWallet(
-        'A9C09B6E4AF70DE1F1B621CB1AA66CFD0B4AA977E4C18497C49132DD9E579485',
-        null,
-        false,
-        'My wallet 3',
-      ).then(setupFinished => {
+      cy.setupWallet({
+        privateKey:
+          'A9C09B6E4AF70DE1F1B621CB1AA66CFD0B4AA977E4C18497C49132DD9E579485',
+        walletName: 'My wallet 3',
+      }).then(setupFinished => {
         expect(setupFinished).to.be.true;
       });
     });


### PR DESCRIPTION
## Motivation and context
Updated the style of args accepted by `cy.setupWallet`. previously it accepted multiple params individually. now all params are passed through a single keyword arg which is desctructred to get the individual params.
we went from
```
cy.setupWallet(
        'A9C09B6E4AF70DE1F1B621CB1AA66CFD0B4AA977E4C18497C49132DD9E579485',
        null,
        false,
        'My wallet 3',
      )
```
to
```
cy.setupWallet({
        privateKey:
          'A9C09B6E4AF70DE1F1B621CB1AA66CFD0B4AA977E4C18497C49132DD9E579485',
        walletName: 'My wallet 3',
      })
```
This cleans up a lot of the code that users will have to write and ensures that when we keep adding params in the future, it wont create a mess
