### PR TITLE
Fix for switching between keplr windows with same url

### DIFF
--- a/commands/playwright-keplr.js
+++ b/commands/playwright-keplr.js
@@ -340,7 +340,8 @@ module.exports = {
       if (
         page
           .url()
-          .includes(`chrome-extension://${keplrExtensionData.id}/popup.html`)
+          .includes(`chrome-extension://${keplrExtensionData.id}/popup.html`) &&
+        page !== keplrWindow
       ) {
         keplrNotificationWindow = page;
         retries = 0;

--- a/tests/e2e/specs/keplr/keplr-spec.js
+++ b/tests/e2e/specs/keplr/keplr-spec.js
@@ -103,6 +103,16 @@ describe('Keplr', () => {
         expect(tokenValue).to.equal(331);
       });
     });
+    it(`should differntiate between keplrWindow and keplrNotificationWindow when they have the same URL`, () => {
+      cy.getTokenAmount('ATOM').then(tokenValue => {
+        expect(tokenValue).to.equal(0);
+      });
+
+      cy.contains('Make an Offer').click();
+      cy.confirmTransaction().then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
+    });
     it(`should disconnect the wallet from all the connected DAPPs`, () => {
       cy.disconnectWalletFromDapp().then(taskCompleted => {
         expect(taskCompleted).to.be.true;


### PR DESCRIPTION
**Issue**:
If we perform some cypress action that opens the window to `/popup.html` URL (such as `cy.getTokenAmount`), it creates an issue where anytime a acceptTransaction or connectWallet popup is opened after that, our playwright command chooses the incorrect window to switch to.
This is because both windows have the `/popup.html` URL, and playwright decides to navigate to the first window open, (which in our case is the `keplrWindow` instead of the `keplrNotificationWindow`)

**Fix**:
The fix for this is to check if the window we are switching to is not equal to the `keplrWindow` object we have stored globally. This allows us to always switch to the correct window