### PR TITLE
Fix Flakiness in add new tokens command

### DIFF
--- a/commands/keplr.js
+++ b/commands/keplr.js
@@ -333,8 +333,9 @@ const keplr = {
       await module.exports.goToHome();
     }
     await playwright.waitAndClickByText(homePageElements.newTokensFound);
-    await playwright.waitAndClickWithRetry(
+    await playwright.waitAndClickWithDelay(
       homePageElements.selectAllTokensCheck,
+      2000,
       { number: -1, force: true },
     );
     await playwright.waitAndClickByText(

--- a/commands/playwright-keplr.js
+++ b/commands/playwright-keplr.js
@@ -327,7 +327,7 @@ module.exports = {
 
     throw new Error(`Failed to click element after ${maxRetries} attempts`);
   },
-  async waitAndClickWithDelay(selector, options, delay) {
+  async waitAndClickWithDelay(selector, delay, options) {
     const page = module.exports.keplrWindow();
     await page.waitForTimeout(delay);
     await module.exports.waitAndClick(selector, page, options);


### PR DESCRIPTION
This PR fixes the flakiness on clicking the select all checkbox for adding new token by waiting for the sliding window to appear and then clicking it.