### PR TITLE
fix: select chains using array in import wallet flow

### DIFF
--- a/commands/keplr.js
+++ b/commands/keplr.js
@@ -98,6 +98,7 @@ const keplr = {
     password,
     newAccount,
     walletName,
+    selectedChains,
   ) {
     await module.exports.goToRegistration();
     await playwright.waitAndClickByText(
@@ -158,7 +159,7 @@ const keplr = {
       await playwright.keplrWindow(),
     );
 
-    await module.exports.handleSelectChain();
+    await module.exports.handleSelectChain(selectedChains);
 
     await playwright.waitForByText(
       onboardingElements.phraseAccountCreated,
@@ -167,20 +168,22 @@ const keplr = {
 
     return true;
   },
-  async handleSelectChain() {
-    const chainNameExists = await playwright.waitForAndCheckElementExistence(
-      onboardingElements.chainNameSelector,
+  async handleSelectChain(selectedChains) {
+    for (const chain of selectedChains) {
+      await playwright.waitAndClickByText(
+        chain,
+        playwright.keplrWindow(),
+        true,
+      );
+    }
+
+    await playwright.waitAndClick(
+      onboardingElements.submitChainButton,
+      playwright.keplrWindow(),
     );
 
-    if (chainNameExists) {
-      await playwright.waitAndClickByText(
-        onboardingElements.chainName,
-        playwright.keplrWindow(),
-      );
-      await playwright.waitAndClick(
-        onboardingElements.submitChainButton,
-        playwright.keplrWindow(),
-      );
+    // eslint-disable-next-line no-unused-vars
+    for (const _ of selectedChains) {
       const importButtonExists =
         await playwright.waitForAndCheckElementExistence(
           onboardingElements.importButtonSelector,
@@ -191,12 +194,9 @@ const keplr = {
           onboardingElements.importButtonSelector,
           playwright.keplrWindow(),
         );
+      } else {
+        break;
       }
-    } else {
-      await playwright.waitAndClick(
-        onboardingElements.submitChainButton,
-        playwright.keplrWindow(),
-      );
     }
   },
   async importWalletWithPhrase(secretWords) {
@@ -291,7 +291,13 @@ const keplr = {
 
   async initialSetup(
     playwrightInstance,
-    { secretWordsOrPrivateKey, password, newAccount, walletName },
+    {
+      secretWordsOrPrivateKey,
+      password,
+      newAccount,
+      walletName,
+      selectedChains,
+    },
   ) {
     if (playwrightInstance) {
       await playwright.init(playwrightInstance);
@@ -307,6 +313,7 @@ const keplr = {
       password,
       newAccount,
       walletName,
+      selectedChains,
     );
     await playwright.switchToCypressWindow();
   },

--- a/pages/keplr/first-time-flow-page.js
+++ b/pages/keplr/first-time-flow-page.js
@@ -14,8 +14,6 @@ const phraseAccountCreated = 'Account Created!';
 const finishButton = 'button[type="button"]';
 const textAreaSelector = 'textbox';
 const submitPhraseButton = 'button[type="submit"]';
-const chainName = 'Agoric local';
-const chainNameSelector = 'text=Agoric local';
 const importButtonSelector = 'button:has-text("Import")';
 
 module.exports.onboardingElements = {
@@ -23,7 +21,6 @@ module.exports.onboardingElements = {
   createWalletButton,
   importRecoveryPhraseButton,
   useRecoveryPhraseButton,
-  chainNameSelector,
   importButtonSelector,
   phraseCount24,
   phrasePrivateKey,
@@ -37,5 +34,4 @@ module.exports.onboardingElements = {
   finishButton,
   textAreaSelector,
   submitPhraseButton,
-  chainName,
 };

--- a/plugins/keplr-plugin.js
+++ b/plugins/keplr-plugin.js
@@ -77,12 +77,14 @@ module.exports = (on, config) => {
       password,
       newAccount,
       walletName,
+      selectedChains,
     }) => {
       await keplr.initialSetup(null, {
         secretWordsOrPrivateKey,
         password,
         newAccount,
         walletName,
+        selectedChains,
       });
       return true;
     },

--- a/support/commands.js
+++ b/support/commands.js
@@ -417,6 +417,7 @@ Cypress.Commands.add('setupWallet', (args = {}) => {
     password = 'Test1234',
     newAccount = false,
     walletName = 'My Wallet',
+    selectedChains = [],
   } = args;
   return cy.task('setupWallet', {
     secretWordsOrPrivateKey:
@@ -426,6 +427,7 @@ Cypress.Commands.add('setupWallet', (args = {}) => {
     password,
     newAccount,
     walletName,
+    selectedChains,
   });
 });
 

--- a/support/index.d.ts
+++ b/support/index.d.ts
@@ -520,6 +520,7 @@ declare namespace Cypress {
       password?: string;
       newAccount?: boolean;
       walletName?: string;
+      selectedChains?: Array<string>;
     }): Chainable<Subject>;
   }
 }

--- a/tests/e2e/specs/keplr/keplr-spec.js
+++ b/tests/e2e/specs/keplr/keplr-spec.js
@@ -62,6 +62,7 @@ describe('Keplr', () => {
         password: 'Test1234',
         newAccount: true,
         walletName: 'My Wallet 2',
+        selectedChains: ['Agoric localhost', 'Secret Network'],
       }).then(setupFinished => {
         expect(setupFinished).to.be.true;
       });
@@ -71,6 +72,7 @@ describe('Keplr', () => {
         privateKey:
           'A9C09B6E4AF70DE1F1B621CB1AA66CFD0B4AA977E4C18497C49132DD9E579485',
         walletName: 'My wallet 3',
+        selectedChains: ['Agoric localhost'],
       }).then(setupFinished => {
         expect(setupFinished).to.be.true;
       });


### PR DESCRIPTION
This PR replaces the code in the import wallet flow which selected Agoric Localhost chain automatically if it was present. This has instead been replaced by an array argument that can be used to list what chains to select.

The following issues are also fixed:

chain is selected using exact match now
the select divergent chain screen runs for every chain selected, so it now runs in a loop