### PR TITLE
feat: integrate custom cypress command for executing shell commands

### DIFF
--- a/plugins/keplr-plugin.js
+++ b/plugins/keplr-plugin.js
@@ -1,3 +1,4 @@
+const { exec, execSync } = require('child_process');
 const helpers = require('../helpers');
 const playwright = require('../commands/playwright-keplr');
 const keplr = require('../commands/keplr');
@@ -54,6 +55,19 @@ module.exports = (on, config) => {
       console.log('\u001B[36m', 'INFO:', message, '\u001B[0m');
       return true;
     },
+
+    async execute(command) {
+      return new Promise((resolve, reject) => {
+        exec(command, (error, stdout, stderr) => {
+          if (error) {
+            reject({ error, stdout, stderr });
+          } else {
+            resolve({ stdout, stderr });
+          }
+        });
+      });
+    },
+
     // playwright commands for Keplr
     initPlaywright: playwright.init,
     assignWindows: playwright.assignWindows,

--- a/support/commands.js
+++ b/support/commands.js
@@ -476,3 +476,7 @@ Cypress.Commands.add('addNewTokensFound', () => {
 Cypress.Commands.add('getTokenAmount', tokenName => {
   return cy.task('getTokenAmount', { tokenName });
 });
+
+Cypress.Commands.add('execute', command => {
+  return cy.task('execute', command);
+});

--- a/tests/e2e/specs/keplr/keplr-spec.js
+++ b/tests/e2e/specs/keplr/keplr-spec.js
@@ -2,6 +2,16 @@
 
 describe('Keplr', () => {
   context('Test commands', () => {
+    it('Executes a command and verifies stdout and stderr', () => {
+      const command = 'echo "Hello, stdout!" && echo "Error occurred" >&2';
+
+      cy.execute(command).then(({ stdout, stderr, error }) => {
+        expect(stdout.trim()).to.equal('Hello, stdout!');
+        expect(stderr.trim()).to.equal('Error occurred');
+        expect(error).to.be.undefined;
+      });
+    });
+
     it(`should complete Keplr setup by  importing an existing wallet using 24 word phrase`, () => {
       cy.setupWallet().then(setupFinished => {
         expect(setupFinished).to.be.true;


### PR DESCRIPTION
The PR adds a custom Cypress command which can be used to execute shell commands. It uses `exec` child process in NodeJS