### PR TITLE
refactor: removed newAccount param from setupWallet

### DIFF
--- a/commands/keplr.js
+++ b/commands/keplr.js
@@ -178,30 +178,19 @@ const keplr = {
   async importWallet(
     secretWordsOrPrivateKey,
     password,
-    newAccount,
     walletName,
     selectedChains,
   ) {
     await module.exports.goToRegistration();
     await playwright.waitAndClickByText(
-      newAccount
-        ? onboardingElements.createWalletButton
-        : onboardingElements.existingWalletButton,
+      onboardingElements.existingWalletButton,
       await playwright.keplrWindow(),
     );
 
     await playwright.waitAndClickByText(
-      newAccount
-        ? onboardingElements.importRecoveryPhraseButton
-        : onboardingElements.useRecoveryPhraseButton,
+      onboardingElements.useRecoveryPhraseButton,
       await playwright.keplrWindow(),
     );
-
-    newAccount &&
-      (await playwright.waitAndClickByText(
-        onboardingElements.useRecoveryPhraseButton,
-        await playwright.keplrWindow(),
-      ));
 
     if (secretWordsOrPrivateKey.includes(' ')) {
       await module.exports.importWalletWithPhrase(
@@ -377,7 +366,6 @@ const keplr = {
     {
       secretWordsOrPrivateKey,
       password,
-      newAccount,
       walletName,
       selectedChains,
       createNewWallet,
@@ -398,7 +386,6 @@ const keplr = {
       await module.exports.importWallet(
         secretWordsOrPrivateKey,
         password,
-        newAccount,
         walletName,
         selectedChains,
       );

--- a/pages/keplr/first-time-flow-page.js
+++ b/pages/keplr/first-time-flow-page.js
@@ -1,6 +1,5 @@
 const createWalletButton = 'Create a new wallet';
 const existingWalletButton = 'Import an existing wallet';
-const importRecoveryPhraseButton = 'Import existing recovery phrase';
 const createNewRecoveryPhraseButton = 'Create new recovery phrase';
 const showMyPhraseButton = 'I understood. Show my phrase.';
 const copyToClipboardButton = 'Copy to clipboard';
@@ -24,7 +23,6 @@ const importButtonSelector = 'button:has-text("Import")';
 module.exports.onboardingElements = {
   existingWalletButton,
   createWalletButton,
-  importRecoveryPhraseButton,
   createNewRecoveryPhraseButton,
   showMyPhraseButton,
   copyToClipboardButton,

--- a/plugins/keplr-plugin.js
+++ b/plugins/keplr-plugin.js
@@ -97,7 +97,6 @@ module.exports = (on, config) => {
     setupWallet: async ({
       secretWordsOrPrivateKey,
       password,
-      newAccount,
       walletName,
       selectedChains,
       createNewWallet,
@@ -105,7 +104,6 @@ module.exports = (on, config) => {
       await keplr.initialSetup(null, {
         secretWordsOrPrivateKey,
         password,
-        newAccount,
         walletName,
         selectedChains,
         createNewWallet,

--- a/support/commands.js
+++ b/support/commands.js
@@ -415,7 +415,6 @@ Cypress.Commands.add('setupWallet', (args = {}) => {
     secretWords,
     privateKey,
     password = 'Test1234',
-    newAccount = false,
     walletName = 'My Wallet',
     selectedChains = [],
     createNewWallet = false,
@@ -426,7 +425,6 @@ Cypress.Commands.add('setupWallet', (args = {}) => {
       privateKey ||
       'orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology',
     password,
-    newAccount,
     walletName,
     selectedChains,
     createNewWallet,

--- a/support/index.d.ts
+++ b/support/index.d.ts
@@ -518,7 +518,6 @@ declare namespace Cypress {
       secretWords?: string;
       privateKey?: string;
       password?: string;
-      newAccount?: boolean;
       walletName?: string;
       selectedChains?: Array<string>;
       createNewWallet?: boolean;

--- a/tests/e2e/specs/keplr/keplr-spec.js
+++ b/tests/e2e/specs/keplr/keplr-spec.js
@@ -86,12 +86,11 @@ describe('Keplr', () => {
         'Offer accepted',
       );
     });
-    it(`should create a new wallet using 24 word phrase`, () => {
+    it(`should import a wallet and add selected chains`, () => {
       cy.setupWallet({
         secretWords:
           'orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology',
         password: 'Test1234',
-        newAccount: true,
         walletName: 'My Wallet 2',
         selectedChains: ['Agoric localhost', 'Secret Network'],
       }).then(setupFinished => {


### PR DESCRIPTION
## Motivation and context

This PR updates the params of the `setupWallet` command and removes the `newAccount` field.
This field is being removed because:
- it serves a function similar to the default behaviour of setupWallet
- its naming clashes with the `createNewWallet` param

## Does it fix any issue?

#47 

