### PR TITLE
fix Кeplr confirm tx - wasm execute

### DIFF
--- a/pages/keplr/notification-page.js
+++ b/pages/keplr/notification-page.js
@@ -1,4 +1,4 @@
-const approveButton = `button`;
+const approveButton = `//button[div[contains(text(), 'Approve')]]`;
 const copyAddress = 'Copy Address';
 const walletSelectors = chainName => `img[alt="${chainName}"]`;
 


### PR DESCRIPTION
## Motivation and context

The **confirmTransactions** (Keplr) function does not work correctly when attempting to confirm a transaction that executes an execMsg to a contract. This branch is my view of what the problem is and how it works for me.

## Versions

- _"@agoric/synpress"_ - v3.8.1 (Latest)
- _Keplr_ - Default version (not using _KEPLR_VERSION_)

## Current behavior

The "Details" button is clicked.

## Expected behavior

The "Approve" button is clicked.

## Other useful info

Based on my observations, the issue occurs because additional information appears on the confirmation page in these cases, accompanied by an extra button "Details" (have a look at the pictures). However, the current implementation assumes that there is only one button on this page: https://github.com/agoric-labs/synpress/blob/dev/pages/keplr/notification-page.js#L1. That's why the first 'button' is pressed.

![keplr1](https://github.com/user-attachments/assets/9797ad63-2729-4be4-9cba-b71625b896d0)
![keplr2](https://github.com/user-attachments/assets/d02f7353-620c-4655-a665-e8087f458d65)


## Quality checklist

- [ x] I have performed a self-review of my code.
- [  ] If it is a core feature, I have added thorough e2e tests.
