### PR TITLE
Handles multiple Keplr popup notifications simultaneously

### DIFF
--- a/commands/keplr.js
+++ b/commands/keplr.js
@@ -317,6 +317,15 @@ const keplr = {
     return true;
   },
 
+  async acceptAccessWithoutWaitForEvent() {
+    const notificationPage = await playwright.switchToKeplrNotification();
+    await playwright.waitAndClick(
+      notificationPageElements.approveButton,
+      notificationPage,
+    );
+    return true;
+  },
+
   async rejectAccess() {
     const notificationPage = await playwright.switchToKeplrNotification();
     await notificationPage.close();

--- a/plugins/keplr-plugin.js
+++ b/plugins/keplr-plugin.js
@@ -89,6 +89,7 @@ module.exports = (on, config) => {
     // keplr commands
     importWallet: keplr.importWallet,
     acceptAccess: keplr.acceptAccess,
+    acceptAccessWithoutWaitForEvent: keplr.acceptAccessWithoutWaitForEvent,
     rejectAccess: keplr.rejectAccess,
     getWalletAddress: keplr.getWalletAddress,
     confirmTransaction: keplr.confirmTransaction,

--- a/support/commands.js
+++ b/support/commands.js
@@ -435,6 +435,10 @@ Cypress.Commands.add('acceptAccess', () => {
   return cy.task('acceptAccess');
 });
 
+Cypress.Commands.add('acceptAccessWithoutWaitForEvent', () => {
+  return cy.task('acceptAccessWithoutWaitForEvent');
+});
+
 Cypress.Commands.add('rejectAccess', () => {
   return cy.task('rejectAccess');
 });

--- a/tests/e2e/specs/keplr/keplr-without-wait-for-event.js
+++ b/tests/e2e/specs/keplr/keplr-without-wait-for-event.js
@@ -1,0 +1,63 @@
+/* eslint-disable ui-testing/no-disabled-tests */
+
+describe('Keplr', () => {
+  context('Test commands', () => {
+    const scriptsFolder = Cypress.config('bashScriptsFolder');
+    it('Executes a command and verifies stdout and stderr', () => {
+      const command = 'echo "Hello, stdout!" && echo "Error occurred" >&2';
+
+      cy.execute(command).then(({ stdout, stderr, error }) => {
+        expect(stdout.trim()).to.equal('Hello, stdout!');
+        expect(stderr.trim()).to.equal('Error occurred');
+        expect(error).to.be.undefined;
+      });
+    });
+
+    it('Executes a commands from a file and verifies stdout and stderr', () => {
+      const fileName = 'script.sh';
+
+      cy.execute(`sh ${scriptsFolder}/${fileName}`).then(
+        ({ stdout, stderr, error }) => {
+          expect(stdout.trim()).to.equal('Hello, stdout!');
+          expect(stderr.trim()).to.equal('Error occurred');
+          expect(error).to.be.undefined;
+        },
+      );
+    });
+
+    it(`should create a brand new wallet`, () => {
+      cy.setupWallet({
+        createNewWallet: true,
+        walletName: 'my created wallet',
+      }).then(setupFinished => {
+        expect(setupFinished).to.be.true;
+      });
+    });
+    it(`should complete Keplr setup by  importing an existing wallet using 24 word phrase`, () => {
+      cy.setupWallet().then(setupFinished => {
+        expect(setupFinished).to.be.true;
+      });
+      cy.visit('/');
+    });
+    it(`should reject connection with wallet`, () => {
+      const alertShown = cy.stub().as('alertShown');
+      cy.on('window:alert', alertShown);
+
+      cy.contains('Connect Wallet').click();
+      cy.rejectAccess().then(rejected => {
+        expect(rejected).to.be.true;
+      });
+      cy.get('@alertShown').should(
+        'have.been.calledOnceWith',
+        'Request rejected',
+      );
+    });
+    it(`should accept connection with wallet with "acceptAccessWithoutWaitForEvent"`, () => {
+      cy.contains('Connect Wallet').click();
+      cy.acceptAccessWithoutWaitForEvent().then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
+      cy.contains('Make an Offer').should('exist');
+    });
+  });
+});

--- a/tests/e2e/specs/keplr/keplr-without-wait-for-event.js
+++ b/tests/e2e/specs/keplr/keplr-without-wait-for-event.js
@@ -1,58 +1,18 @@
 /* eslint-disable ui-testing/no-disabled-tests */
 
+before(() => {
+  cy.setupWallet({
+    createNewWallet: true,
+    walletName: 'New Test Wallet',
+  }).then(setupFinished => {
+    expect(setupFinished).to.be.true;
+  });
+});
+
 describe('Keplr', () => {
-  context('Test commands', () => {
-    const scriptsFolder = Cypress.config('bashScriptsFolder');
-    it('Executes a command and verifies stdout and stderr', () => {
-      const command = 'echo "Hello, stdout!" && echo "Error occurred" >&2';
-
-      cy.execute(command).then(({ stdout, stderr, error }) => {
-        expect(stdout.trim()).to.equal('Hello, stdout!');
-        expect(stderr.trim()).to.equal('Error occurred');
-        expect(error).to.be.undefined;
-      });
-    });
-
-    it('Executes a commands from a file and verifies stdout and stderr', () => {
-      const fileName = 'script.sh';
-
-      cy.execute(`sh ${scriptsFolder}/${fileName}`).then(
-        ({ stdout, stderr, error }) => {
-          expect(stdout.trim()).to.equal('Hello, stdout!');
-          expect(stderr.trim()).to.equal('Error occurred');
-          expect(error).to.be.undefined;
-        },
-      );
-    });
-
-    it(`should create a brand new wallet`, () => {
-      cy.setupWallet({
-        createNewWallet: true,
-        walletName: 'my created wallet',
-      }).then(setupFinished => {
-        expect(setupFinished).to.be.true;
-      });
-    });
-    it(`should complete Keplr setup by  importing an existing wallet using 24 word phrase`, () => {
-      cy.setupWallet().then(setupFinished => {
-        expect(setupFinished).to.be.true;
-      });
-      cy.visit('/');
-    });
-    it(`should reject connection with wallet`, () => {
-      const alertShown = cy.stub().as('alertShown');
-      cy.on('window:alert', alertShown);
-
-      cy.contains('Connect Wallet').click();
-      cy.rejectAccess().then(rejected => {
-        expect(rejected).to.be.true;
-      });
-      cy.get('@alertShown').should(
-        'have.been.calledOnceWith',
-        'Request rejected',
-      );
-    });
+  context('Test new commands', () => {
     it(`should accept connection with wallet with "acceptAccessWithoutWaitForEvent"`, () => {
+      cy.visit('/');
       cy.contains('Connect Wallet').click();
       cy.acceptAccessWithoutWaitForEvent().then(taskCompleted => {
         expect(taskCompleted).to.be.true;


### PR DESCRIPTION
## Motivation and context

This handles the situation where Keplr popup displays two notifications simultaneously. 
Typically, we expect that after one notification is accepted or approved, the popup should disappear without showing any further notifications. 

This is most likely due to Keplr not having the info of the chain.

## Does it fix any issue?

#(issue)

## Other useful info

To test this, you could point the test to https://elaisee.mantrachain.io/ which uses MANTRA chain which is not available in Keplr 0.12.68 that the current dev branch is using.

## Quality checklist

- [x] I have performed a self-review of my code.

**⚠️👆 Delete any section you see irrelevant before submitting the pull request 👆⚠️**
